### PR TITLE
Fix minor filename issue

### DIFF
--- a/credit-risk/notebooks/1-ML-Model-Full-Version.ipynb
+++ b/credit-risk/notebooks/1-ML-Model-Full-Version.ipynb
@@ -1385,7 +1385,7 @@
    "outputs": [],
    "source": [
     "# Incase you don't have graphviz installed\n",
-    "# txt = open(\"tree_3.dot\").read().replace(\"\\\\n\", \"\\n  \").replace(\";\", \";\\n\")\n",
+    "# txt = open(\"tree.dot\").read().replace(\"\\\\n\", \"\\n  \").replace(\";\", \";\\n\")\n",
     "# print(txt)"
    ]
   },


### PR DESCRIPTION
The file is named tree.dot and not tree_3.dot as in the comment.
Command in comment fails if executed. This minor patch prevents that.